### PR TITLE
fix: variables are not defined

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -11,7 +11,6 @@
 		"quotes": [2, "single"],
 		"eqeqeq": 0,
 		"strict": 0,
-		"no-undef": 0,
 		"semi": [2, "always"]
 	}
 }

--- a/src/angular-selector.js
+++ b/src/angular-selector.js
@@ -3,6 +3,8 @@
 	// Key codes
 	var KEYS = { up: 38, down: 40, left: 37, right: 39, escape: 27, enter: 13, backspace: 8, delete: 46, shift: 16, leftCmd: 91, rightCmd: 93, ctrl: 17, alt: 18, tab: 9 };
 	
+	var $filter, $timeout, $window, $http, $q;
+	
 	var Selector = (function () {
 		
 		function getStyles(element) {


### PR DESCRIPTION
- fix: variables are not defined

$filter, $timeout, $window, $http, $q are not defined before they are used.
Error is visible once file is minified.
ESLinter reports it as well!
- chore: configure ESLint correctly

it is a general good practice to not leak variables to the global scope
recommended settings already define that scenario "eslint:recommended"
