### PR TITLE
Bug when you delete the last option in a multi selector

### DIFF
--- a/src/angular-selector.js
+++ b/src/angular-selector.js
@@ -332,6 +332,9 @@
 					
 					if (!scope.multiple) scope.selectedValues = [option];
 					else {
+						if(!scope.selectedValues){
+							scope.selectedValues = [];
+						}
 						if (scope.selectedValues.indexOf(option) < 0)
 							scope.selectedValues.push(option);
 					}


### PR DESCRIPTION
The selectedValues was being set to `''` instead of `[]` with `input.val('');`

This new change ensures there is always a selectedValues array to which a value can be pushed.
